### PR TITLE
Added Swift version to podspec

### DIFF
--- a/CRNotifications.podspec
+++ b/CRNotifications.podspec
@@ -15,6 +15,7 @@ CRNotifications are custom in-app notifications with 3 types of layouts. The not
   s.social_media_url = 'https://twitter.com/dkcas11'
 
   s.ios.deployment_target = '9.0'
+  s.swift_version = '4.0'
 
   s.source_files = 'CRNotifications/Classes/**/*'
   s.resources    = "CRNotifications/Assets/*.xcassets"


### PR DESCRIPTION
CRNotifications will not build for me in Xcode 10.1 unless I manually change the Swift version in the pod settings. This PR fixes it by specifying the swift version in the podspec.